### PR TITLE
[DOCS] Use structure from example documentation

### DIFF
--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -6,12 +6,12 @@
 .. role:: js(code)
 .. role:: php(code)
 .. role:: sep (strong)
-.. role:: shell(code)
-.. role:: yaml(code)
-.. role:: underline
+.. role:: sql(code)
 .. role:: typoscript(code)
+.. role:: yaml(code)
 
 .. role:: ts(typoscript)
    :class: typoscript
 
+.. default-role:: code
 .. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,7 +1,4 @@
-.. include:: Includes.txt
-
-.. Every manual should have a start label for cross-referencing to
-.. start page. Do not remove this!
+.. include:: /Includes.txt
 
 .. _start:
 
@@ -9,22 +6,41 @@
 Crawler Widgets
 ===============
 
-:Classification:  typo3-crawler-widgets
-:Version:         |release|
-:Language:        en
-:Description:     Widgets for the EXT:crawler
-:Keywords:        widgets, crawler
-:Copyright:       2020
-:Author:          Philipp Kuhlmay
-:Email:           mail@treupo.de
-:License:         This document is published under the Open Content License available from
-                  https://www.opencontent.org/openpub/
-:Rendered:        |today|
+:Version:
+   |release|
 
-The content of this document is related to TYPO3, a GNU/GPL CMS/Framework available from https://typo3.org/.
+:Language:
+   en
+
+:Authors:
+   Tomas Norre Mikkelsen, Philipp Kuhlmay, Chris Müller
+
+:License:
+   This extension documentation is published under the
+   `CC BY-NC-SA 4.0 <https://creativecommons.org/licenses/by-nc-sa/4.0/>`__ (Creative Commons)
+   license
+
+Dashboard widgets for the extension "crawler"
+
+**TYPO3**
+
+The content of this document is related to TYPO3 CMS,
+a GNU/GPL CMS/Framework available from `typo3.org <https://typo3.org/>`_ .
+
+**Extension Manual**
+
+This documentation is for the TYPO3 extension crawler_widget.
+
+If you find an error or something is missing, please:
+`Report a Problem <https://github.com/tomasnorre/typo3-crawler-widget/issues/new>`__
+
+**For Contributors**
+
+You are welcome to help improve this guide.
+Just click on "Edit me on GitHub" on the top right to submit your change request.
 
 .. toctree::
-   :hidden:
+   :maxdepth: 3
 
    Widgets/Index
-
+   Sitemap

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,12 @@
+[general]
+project = Crawler Widget
+release = {extension.version}
+copyright = by TYPO3 Crawler Team
+
+[html_theme_options]
+project_home = https://github.com/tomasnorre/typo3-crawler-widget
+project_issues = https://github.com/tomasnorre/typo3-crawler-widget/issues
+project_repository = https://github.com/tomasnorre/typo3-crawler-widget
+
+[intersphinx_mapping]
+t3dashboard = https://docs.typo3.org/c/typo3/cms-dashboard/10.4/en-us/

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,0 +1,9 @@
+:template: sitemap.html
+
+.. _sitemap:
+
+=======
+Sitemap
+=======
+
+.. template 'sitemap.html' will insert the toctree as a sitemap here below normal contents

--- a/Documentation/Widgets/Index.rst
+++ b/Documentation/Widgets/Index.rst
@@ -1,4 +1,6 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.txt
+
+.. _widgets:
 
 =======
 Widgets
@@ -10,14 +12,19 @@ Widgets
 
 .. hint::
 
-    To add a widget to your dashboard you need to click on the plus button in the dashboard module and select the tab 'Crawler'. There you will find all our widgets.
+   To add a widget to your dashboard you need to click on the plus button in the
+   dashboard module and select the tab :guilabel:`Crawler`. There you will find
+   all our widgets.
 
 .. note::
 
-   Please note, that the permissions for editors have to be granted to be able to use these widgets.
+   Please note, that the :ref:`permissions for editors
+   <t3dashboard:permission-handling-of-widgets>` have to be granted to be able
+   to use these widgets.
+
 
 Displaying the queue size
--------------------------
+=========================
 
 This widgets displays the size of the queue.
 


### PR DESCRIPTION
- Adjust start page according to example documentation
- Use max. 80 chars for each line
- Add anchors

Todo:
- When release is done, the version should be adjusted (placeholder {extension.version})

See: https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual