### PR TITLE
Crawler 10 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog TYPO3 Crawler widget
 
+## Version 1.1.0
+
+### Added
+
+* Support for EXT:crawler 10.0
+
 ## Version 1.0.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # typo3-crawler_widget
 A collection of widgets for the TYPO3 Crawler that give TYPO3 backend users information about the status of Crawler.
+
+## Available widgets
+- Displaying the queue size

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"typo3/cms-core": "^10.4 || ^11.0",
-		"typo3/cms-dashboard": "^10.4 || ^11.0",
+		"typo3/cms-core": "^10.4 || ^11.3",
+		"typo3/cms-dashboard": "^10.4 || ^11.3",
 		"aoepeople/crawler": "^9.0 || ^10.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": "^7.2",
 		"typo3/cms-core": "^10.4 || ^11.0",
 		"typo3/cms-dashboard": "^10.4 || ^11.0",
-		"aoepeople/crawler": "^9.0"
+		"aoepeople/crawler": "^9.0 || ^10.0"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.16",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '10.4.0-11.5.99',
             'dashboard' => '10.4.0-11.5.99',
-            'crawler' => '9.0.0-9.9.99'
+            'crawler' => '9.0.0-10.9.99'
         ],
     ],
     'state' => 'stable',
@@ -31,7 +31,7 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Tomas Norre Mikkelsen, Philipp Kuhlmay, Chris Müller',
     'author_email' => 'mail@treupo.de',
     'author_company' => 'FriendsOfCrawler',
-    'version' => '1.0.0',
+    'version' => '1.1.0',
     'autoload' => [
         'psr-4' => [
             'FriendsOfCrawler\CrawlerWidget\\' => 'Classes'


### PR DESCRIPTION
EXT:crawler 10.0 came out. This extension wasn't installable with the EXT:crawler 10.0.0.

I tested it with TYPO3 10.4.18 and TYPO3 11.3.1