### PR TITLE
Set dependencies for TYPO3 11 to 11.5 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"typo3/cms-core": "^10.4 || ^11.3",
-		"typo3/cms-dashboard": "^10.4 || ^11.3",
+		"typo3/cms-core": "^10.4 || ^11.5",
+		"typo3/cms-dashboard": "^10.4 || ^11.5",
 		"tomasnorre/crawler": "^9.0 || ^10.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Since the TYPO3 11 LTS is released, the dependencies should be changed to match the LTS version of 11.5